### PR TITLE
Feature/SAN-6056

### DIFF
--- a/src/android/AppboyPlugin.java
+++ b/src/android/AppboyPlugin.java
@@ -104,13 +104,17 @@ public class AppboyPlugin extends CordovaPlugin {
   @Override
   public boolean execute(final String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
     initializePluginIfAppropriate();
+    
+    if ("initialize".equals(action)) {
+      Log.i(TAG, "Received initialize");
+      initialize(args.getString(0));
+      return true;
+    }
+
     Log.i(TAG, "Received " + action + " with the following arguments: " + args);
 
     // Appboy methods
     switch (action) {
-      case "initialize":
-        initialize(args.getString(0));
-        return true;
       case "registerAppboyPushMessages":
         Appboy.getInstance(mApplicationContext).registerAppboyPushMessages(args.getString(0));
         return true;


### PR DESCRIPTION
Updated AppboyPlugin.execute so it doesn't log the arguments for an initialize call. The argument for initialize is the API key, so we shouldn't be including that in the log.